### PR TITLE
Ensure spaces are not escaped by ~w sigil

### DIFF
--- a/lib/acme/openssl.ex
+++ b/lib/acme/openssl.ex
@@ -49,18 +49,18 @@ defmodule Acme.OpenSSL do
       #=> {:ok, <<DER-encoded CSR>>
   """
   def generate_csr(private_key_path, subject) do
-    Acme.OpenSSL.openssl ~w(
-      req
-      -new
-      -sha256
-      -nodes
-      -key
-      #{private_key_path}
-      -subj
-      #{format_subject(subject)}
-      -outform
-      DER
-    )
+    Acme.OpenSSL.openssl [
+      "req",
+      "-new",
+      "-sha256",
+      "-nodes",
+      "-key",
+      private_key_path,
+      "-subj",
+      format_subject(subject),
+      "-outform",
+      "DER"
+    ]
   end
 
   @subject_keys %{


### PR DESCRIPTION
The ~w sigil would escape strings in the formatted subject such as the example given with: ```...organization_name: "Acme INC.",...```. This would result in 
```
["req", "-new", "-sha256", "-nodes", "-key", "tls/dev.key.pem", "-subj",
 "\"/CN=example.acme.com/C=US/L=Philadelphia/O=Acme",
 "INC/OU=HR/ST=Pennsylvania\"", "-outform", "DER"]
``` 
And openssl would fail at creating a csr.

As there is no way to escape spaces using the ~w sigil (https://stackoverflow.com/questions/47353187/is-it-possible-to-escape-a-space-in-a-word-list-sigil) it has been replaced with the list syntax.