### PR TITLE
Support config file in CSR generation

### DIFF
--- a/lib/acme/openssl.ex
+++ b/lib/acme/openssl.ex
@@ -41,7 +41,7 @@ defmodule Acme.OpenSSL do
       {:ok, output} = Acme.OpenSSL.verify_csr("/path/to/your/csr.der")
       #=> {:ok, "verify OK\n"}
 
-      {:ok, output} = Acme.OpenSSL.verify_csr("/path/to/your/csr.der", "PEM")
+      {:ok, output} = Acme.OpenSSL.verify_csr("/path/to/your/csr.pem", "PEM")
       #=> {:ok, "verify OK\n"}
   """
   def verify_csr(csr_path, inform \\ "DER") do
@@ -73,9 +73,12 @@ defmodule Acme.OpenSSL do
 
       {:ok, csr} = Acme.OpenSSL.generate_csr("/path/to/your/private_key.pem", subject)
       #=> {:ok, <<DER-encoded CSR>>
+
+      {:ok, csr} = Acme.OpenSSL.generate_csr("/path/to/your/private_key.pem", subject, "/path/to/csr.conf")
+      #=> {:ok, <<DER-encoded CSR>>
   """
-  def generate_csr(private_key_path, subject) do
-    Acme.OpenSSL.openssl([
+  def generate_csr(private_key_path, subject, csr_config_path \\ nil) do
+    openssl_args = [
       "req",
       "-new",
       "-sha256",
@@ -86,7 +89,12 @@ defmodule Acme.OpenSSL do
       format_subject(subject),
       "-outform",
       "DER"
-    ])
+    ]
+
+    case csr_config_path do
+      nil -> Acme.OpenSSL.openssl(openssl_args)
+      _ -> Acme.OpenSSL.openssl(openssl_args ++ ["-config", csr_config_path])
+    end
   end
 
   @subject_keys %{

--- a/lib/acme/openssl.ex
+++ b/lib/acme/openssl.ex
@@ -20,6 +20,12 @@ defmodule Acme.OpenSSL do
     end
   end
 
+  def generate_key({:ec, curve}, key_path) when curve in @ec_curves do
+    with {:ok, _} <- openssl(~w(ecparam -name #{curve} -genkey -out #{key_path})) do
+      {:ok, key_path}
+    end
+  end
+
   def generate_key({:rsa, size}) when size in @rsa_key_sizes do
     openssl(~w(genrsa #{size}))
   end

--- a/lib/acme/openssl.ex
+++ b/lib/acme/openssl.ex
@@ -34,10 +34,27 @@ defmodule Acme.OpenSSL do
     openssl(~w(ecparam -name #{curve} -genkey))
   end
 
-  def generate_key({:ec, curve}, key_path) when curve in @ec_curves do
-    with {:ok, _} <- openssl(~w(ecparam -name #{curve} -genkey -out #{key_path})) do
-      {:ok, key_path}
-    end
+  @doc """
+  Take a csr path and verify the signature, optional argument
+
+  # Example
+      {:ok, output} = Acme.OpenSSL.verify_csr("/path/to/your/csr.der")
+      #=> {:ok, "verify OK\n"}
+
+      {:ok, output} = Acme.OpenSSL.verify_csr("/path/to/your/csr.der", "PEM")
+      #=> {:ok, "verify OK\n"}
+  """
+  def verify_csr(csr_path, inform \\ "DER") do
+    Acme.OpenSSL.openssl(~w(
+      req
+      -noout
+      -text
+      -verify
+      -in
+      #{csr_path}
+      -inform
+      #{inform}
+    ))
   end
 
   @doc """

--- a/test/acme/openssl_test.exs
+++ b/test/acme/openssl_test.exs
@@ -29,11 +29,14 @@ defmodule Acme.OpenSSLTest do
 
   test "generate a csr" do
     key_path = gen_key_path()
+    conf_path = Path.expand("./test/support/csr.conf")
+    csr_path = key_path <> ".csr"
+
     {:ok, _} = OpenSSL.generate_key({:ec, :secp384r1}, key_path)
 
-    assert {:ok, _csr_der} =
-             OpenSSL.generate_csr(key_path, %{
-               common_name: "acme.com"
-             })
+    assert {:ok, csr_der} = OpenSSL.generate_csr(key_path, %{common_name: "acme.com"}, conf_path)
+
+    File.write!(csr_path, csr_der)
+    assert {:ok, _} = OpenSSL.verify_csr(csr_path)
   end
 end

--- a/test/support/csr.conf
+++ b/test/support/csr.conf
@@ -1,0 +1,9 @@
+[ req ]
+distinguished_name = req_distinguished_name
+req_extensions     = req_ext
+[ req_distinguished_name ]
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = acme.com


### PR DESCRIPTION
With the (optional) config file you can build a CSR for SAN certificates. The test has been adapted to use a config.

This PR also adds a csr_verify function, to verify a generated CSR on disk. Now it's used in testing to verify whether the generated CSR is actually valid.